### PR TITLE
readme.md: Fix syntax error in the example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,9 @@
 
  Require in your own modules, and directly access the exposed properties.
  
-    let rpi = require('raspi-ver);
+    let rpi = require('raspi-ver');
  
-    if (rpi.model === "Model B"){
+    if (rpi.model === "Model B") {
  
         console.log("PROFIT");
  


### PR DESCRIPTION
Fix the following error in the example provide in section Usage:

let rpi = require('raspi-ver);
                  ^^^^^^^^^^^^

SyntaxError: Invalid or unexpected token

Signed-off-by: Leon Anavi <leon@anavi.org>