### PR TITLE
versions.json: Add Raspberry Pi Zero W

### DIFF
--- a/lib/versions.json
+++ b/lib/versions.json
@@ -34,6 +34,13 @@
       "memory": "512 MB",
       "notes": "(Mfg by Embest)"
    },
+   "9000c1": {
+      "relDate": "Q1 2017",
+      "model": "Zero W",
+      "PCBRev": "1.1",
+      "memory": "512 MB",
+      "notes": "(Mfg by Sony)"
+   },
    "a32082": {
       "relDate": "Q4 2016",
       "model": "3 model B",


### PR DESCRIPTION
Add Raspberry Pi Zero W version 1.1 according to the revision
code described at:
https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md

Signed-off-by: Leon Anavi <leon@anavi.org>