### PR TITLE
readme.md: Add a link to RASPBERRY PI REVISION CODES

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ The exposed properties of the module.
 
 ## Acknowledgement
 
-All the info returned by the module was taken from [elinux.org](http://elinux.org/RPi_HardwareHistory#Board_Revision_History). Thank you!
+All the info returned by the module was taken from [elinux.org](http://elinux.org/RPi_HardwareHistory#Board_Revision_History) and [raspberrypi.org](https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md). Thank you!
 
 ## LICENSE
 


### PR DESCRIPTION
Add a link to an article at raspberrypi.org called:
RASPBERRY PI REVISION CODES. It contains all the details
for each hardware revision.

In general raspberrypi.org is more reliable than elinux.org
because Raspberry Pi Foundatin is designing all versions and
models of Raspberry Pi.

Signed-off-by: Leon Anavi <leon@anavi.org>