### PR TITLE
Add model 3A+

### DIFF
--- a/lib/versions.json
+++ b/lib/versions.json
@@ -1,4 +1,11 @@
 {
+   "9020e0": {
+      "relDate": "Q4 2018",
+      "model": "3 model A+",
+      "PCBRev": "1.0",
+      "memory": "512 MB",
+      "notes": "(Mfg by Sony)"
+   },
    "a020d3": {
       "relDate": "Q1 2018",
       "model": "3 model B+",


### PR DESCRIPTION
Add definition for raspberry pi 3 model a+ (9020e0) as seen here https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md