### PR TITLE
lib/versions.json: Add Raspberry Pi 4 Model B

### DIFF
--- a/lib/versions.json
+++ b/lib/versions.json
@@ -1,4 +1,11 @@
 {
+   "c03111": {
+      "relDate": "Q2 2019",
+      "model": "4 model B",
+      "PCBRev": "1.1",
+      "memory": "4GB",
+      "notes": ""
+   },
    "9020e0": {
       "relDate": "Q4 2018",
       "model": "3 model A+",


### PR DESCRIPTION
Add Raspberry Pi 4 Model B which has been released in June 2019.
Tested on Raspberry Pi 4 Model B with 4GB RAM.

Signed-off-by: Leon Anavi <leon@anavi.org>